### PR TITLE
add slogan and url fields in events

### DIFF
--- a/API.md
+++ b/API.md
@@ -13,21 +13,25 @@ Example response -
   "events": [
     {
       "end_time": "2015-05-08T16:00:00", 
+      "slogan": "into the wild",
       "id": 3, 
       "latitude": 23.3455, 
       "location_name": "Berlin Station", 
       "longitude": 78.1233, 
       "name": "Re:Publica", 
-      "start_time": "2015-05-01T14:00:00"
+      "start_time": "2015-05-01T14:00:00",
+      "url": "http://14.re-publica.de/"
     }, 
     {
-      "end_time": "2015-06-12T05:00:00", 
+      "end_time": "2015-06-12T05:00:00",
+      "slogan": "IN/SIDE/OUT",
       "id": 4, 
       "latitude": 56.8876, 
       "location_name": "Singapore", 
       "longitude": 123.4567, 
       "name": "FOSSASIA", 
-      "start_time": "2015-06-10T05:00:00"
+      "start_time": "2015-06-10T05:00:00",
+      "url": "http://fossasia.org/"
     }
   ]
 }


### PR DESCRIPTION
re-data has got slogan and url fields, and it makes sense to have them .

@rafalkowalski @mananwason 
this should be merged only after the changes get reflected on all the three components (server, webapp, android) 