### PR TITLE
Fixes #203: adding support yaydoc documentation generation

### DIFF
--- a/.yaydoc.yml
+++ b/.yaydoc.yml
@@ -1,0 +1,13 @@
+metadata:
+  author: FOSSASIA
+  projectname: "Open Event"
+  version: development
+build:
+  theme:
+    name: sphinx_fossasia_theme
+  subproject:
+    - url: https://github.com/fossasia/open-event-orga-server
+    - url: https://github.com/fossasia/open-event-frontend
+    - url: https://github.com/fossasia/open-event-android
+    - url: https://github.com/fossasia/open-event-webapp
+    - url: https://github.com/fossasia/open-event-orga-app


### PR DESCRIPTION
`.yaydoc.yml` is added to support documentation generation from `yaydoc`
Preview: http://yaydoc.herokuapp.com/preview/rbalajis25@gmail.com/946e57e9-6fd8-49e9-af83-697e0fe0872b_preview/