### PR TITLE
Fixed speaker image problem in DroidCon sample

### DIFF
--- a/sample/Droidcon17/speakers
+++ b/sample/Droidcon17/speakers
@@ -35,7 +35,7 @@
     "name": "Annyce Davis",
     "email": "",
     "mobile": "",
-    "photo-url": "/images/speakers/ad.jpg",
+    "photo-url": "/images/speakers/ad.png",
     "sessions": [
       {
         "id": 2,
@@ -407,7 +407,7 @@
     "name": "Chiu-Ki Chan",
     "email": "",
     "mobile": "",
-    "photo-url": "/images/speakers/ckc.jpg",
+    "photo-url": "/images/speakers/ckc.png",
     "sessions": [
       {
         "id": 18,


### PR DESCRIPTION
Fixes issue #218

**Changes**:
* The couple of speakers pictures which was missing while generating a web app for the DroidCon Sample are visible now

**Screenshots**
* Before
![screenshot from 2017-09-04 20-03-04](https://user-images.githubusercontent.com/8847265/30030756-608635ee-91ac-11e7-92ba-2977dad10426.png)
* After
![screenshot from 2017-09-04 19-59-21](https://user-images.githubusercontent.com/8847265/30030770-6f9bc3b4-91ac-11e7-89d3-406e784b14a6.png)

@mariobehling @niranjan94 Please review. Thanks :)